### PR TITLE
refactor: remove unnecessary content server types

### DIFF
--- a/src/Authenticator.ts
+++ b/src/Authenticator.ts
@@ -10,7 +10,6 @@ import {
   EthAddress,
   AuthLinkType,
   IdentityType,
-  AuditInfo,
   AuthLink,
   Signature,
   ValidationResult
@@ -186,10 +185,10 @@ export class Authenticator {
     )
   }
 
-  static ownerAddress(auditInfo: AuditInfo): EthAddress {
-    if (auditInfo.authChain.length > 0) {
-      if (auditInfo.authChain[0].type === AuthLinkType.SIGNER) {
-        return auditInfo.authChain[0].payload
+  static ownerAddress(authChain: AuthChain): EthAddress {
+    if (authChain.length > 0) {
+      if (authChain[0].type === AuthLinkType.SIGNER) {
+        return authChain[0].payload
       }
     }
     return 'Invalid-Owner-Address'

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,33 +23,6 @@ export enum AuthLinkType {
   ECDSA_SIGNED_ENTITY = 'ECDSA_SIGNED_ENTITY'
 }
 
-export type AuditInfo = {
-  version: EntityVersion
-  deployedTimestamp: Timestamp
-
-  authChain: AuthChain
-
-  overwrittenBy?: EntityId
-
-  isBlacklisted?: boolean
-  blacklistedContent?: ContentFileHash[]
-
-  originalMetadata?: {
-    // This is used for migrations
-    originalVersion: EntityVersion
-    data: any
-  }
-}
-export enum EntityVersion {
-  V2 = 'v2',
-  V3 = 'v3'
-}
-
-export type Timestamp = number
-
-export type EntityId = ContentFileHash
-export type ContentFileHash = string
-
 export type AuthIdentity = {
   ephemeralIdentity: IdentityType
   expiration: Date


### PR DESCRIPTION
When the lib was created, some types were copied over from the content server. The problem is, that in this case, it wasn't necessary to copy the `AuditInfo`. 

This is currently causing some problems, since we modified the enum `EntityVersion` in the content server, and now the types are incompatible. 