### PR TITLE
Proposal: allow apps to generate issued chains

### DIFF
--- a/test/authenticator.spec.ts
+++ b/test/authenticator.spec.ts
@@ -57,6 +57,77 @@ describe('Decentraland Crypto', function () {
       expect(result.ok).to.be.equal(true)
     })
 
+    it('should validate request :: issued personal sign', async function () {
+      const identity = EthCrypto.createIdentity()
+      const ephemeral = EthCrypto.createIdentity()
+      const chain = Authenticator.createAuthChain(
+        identity,
+        ephemeral,
+        5,
+        'message',
+        'https://play.decentraland.org'
+      )
+      const result = await Authenticator.validateSignature(
+        'message',
+        chain,
+        new HttpProvider(
+          'https://mainnet.infura.io/v3/640777fe168f4b0091c93726b4f0463a'
+        ),
+        {
+          issuer: 'https://play.decentraland.org'
+        }
+      )
+
+      expect(result.ok).to.be.equal(true)
+    })
+
+    it('should reject request :: unissued personal sign', async function () {
+      const identity = EthCrypto.createIdentity()
+      const ephemeral = EthCrypto.createIdentity()
+      const chain = Authenticator.createAuthChain(
+        identity,
+        ephemeral,
+        5,
+        'message'
+      )
+      const result = await Authenticator.validateSignature(
+        'message',
+        chain,
+        new HttpProvider(
+          'https://mainnet.infura.io/v3/640777fe168f4b0091c93726b4f0463a'
+        ),
+        {
+          issuer: 'https://play.decentraland.org'
+        }
+      )
+
+      expect(result.ok).to.be.equal(false)
+    })
+
+    it('should reject request :: different issued personal sign', async function () {
+      const identity = EthCrypto.createIdentity()
+      const ephemeral = EthCrypto.createIdentity()
+      const chain = Authenticator.createAuthChain(
+        identity,
+        ephemeral,
+        5,
+        'message',
+        'https://decentraland.org'
+      )
+      const result = await Authenticator.validateSignature(
+        'message',
+        chain,
+        new HttpProvider(
+          'https://mainnet.infura.io/v3/640777fe168f4b0091c93726b4f0463a'
+        ),
+        {
+          issuer: 'https://play.decentraland.org'
+        }
+      )
+
+      expect(result.ok).to.be.equal(false)
+    })
+
     it('should validate request :: EIP 1654', async function () {
       const clock = sinon.useFakeTimers(0)
       const chain: AuthChain = [
@@ -122,7 +193,9 @@ describe('Decentraland Crypto', function () {
         new HttpProvider(
           'https://mainnet.infura.io/v3/2c902c2e3b8947d3b34bba7ca48635fc'
         ),
-        1581680328512 // time when deployed
+        {
+          dateToValidateExpirationInMillis: 1581680328512
+        }
       )
 
       expect(result.ok).to.be.equal(true)
@@ -187,7 +260,9 @@ describe('Decentraland Crypto', function () {
         new HttpProvider(
           'https://mainnet.infura.io/v3/2c902c2e3b8947d3b34bba7ca48635fc'
         ),
-        1584541612291
+        {
+          dateToValidateExpirationInMillis: 1584541612291
+        } 
       )
 
       expect(result.ok).to.be.equal(true)
@@ -198,6 +273,9 @@ describe('Decentraland Crypto', function () {
       const clock = sinon.useFakeTimers(0)
       const ephemeral = '0x1F19d3EC0BE294f913967364c1D5B416e6A74555'
       const authority = '0x3B21028719a4ACa7EBee35B0157a6F1B0cF0d0c5'
+      const provider = new HttpProvider(
+        'https://mainnet.infura.io/v3/640777fe168f4b0091c93726b4f0463a'
+      )
       const authLink = {
         type: AuthLinkType.ECDSA_EIP_1654_EPHEMERAL,
         payload: `Decentraland Login\r\nEphemeral address: ${ephemeral}\r\nExpiration: Tue Jan 21 2020 16:34:32 GMT+0000 (Coordinated Universal Time)`,
@@ -208,9 +286,7 @@ describe('Decentraland Crypto', function () {
         authority,
         authLink,
         {
-          provider: new HttpProvider(
-            'https://mainnet.infura.io/v3/640777fe168f4b0091c93726b4f0463a'
-          ),
+          provider,
           dateToValidateExpirationInMillis: Date.now()
         }
       )
@@ -351,7 +427,9 @@ describe('Decentraland Crypto', function () {
         new HttpProvider(
           'https://mainnet.infura.io/v3/640777fe168f4b0091c93726b4f0463a'
         ),
-        moveMinutes(-10).getTime()
+        {
+          dateToValidateExpirationInMillis: moveMinutes(-10).getTime()
+        }
       )
 
       expect(result.ok).to.be.equal(true)


### PR DESCRIPTION
## Tech summary

This proposal adds a new optional parameter `issuer` to `Authenticator.createAuthChain` and an equivalent options to `Authenticator.validateSignature` and `parseEmphemeralPayload` that allow applications to generate and validate `AuthChain`s with an arbritary issuer

## How it looks

```json
[
  {
    "type": "SIGNER",
    "payload": "0x7E0BBe994DA0aC7ab5E02E50185fdAd63Ea2E32B",
    "signature": ""
  },
  {
    "type": "ECDSA_EPHEMERAL",
    "payload": "Decentraland Login\nEphemeral address: 0x4E6bEaCbbA3390a27434b840D21C6f915db21E5B\nExpiration: 2020-09-07T13:21:39.665Z\nIssuer: https://market.decentraland.org",
    "signature": "0xc9bbd8c0f3f191efd8040e79e77954f8ff5b6b5d783e5dd9609e053adb11bc827bfc256192ffec85b5a6dea7418f7cb06c33926919587f914366e6cc55d82d201c"
  },
  {
    "type": "ECDSA_SIGNED_ENTITY",
    "payload": "message",
    "signature": "0xe6a952b2cfbc281b9afd1ddabf06e25df74938aba06a17160d63e0076e77bdf50e868ad88577fb6cdee9ef3537fb000a63f3f63b2fd648273c0580c678cbcfe51b"
  }
]
```

## Cross-App Chain Utilization

This proposal prevent the utilization of a chain generated in other applications

## Massive session invalidation

This proposal allows invalidating all session by changing  the issuer in the server

## How to use

#### Front: generate chains
```typescript
/// front: generate an global chain
const currentChain = Authenticator.createAuthChain(identity, ephemeral, expiration, message)
```

```typescript
/// front: generate an issued chain for market.decentraland.org'
const marketChain = Authenticator.createAuthChain(identity, ephemeral, expiration, message, 'https://market.decentraland.org' /* < new param */)
```

```typescript
/// front: generate an issued chain for events.decentraland.org'
const eventsChain = Authenticator.createAuthChain(identity, ephemeral, expiration, message, 'https://events.decentraland.org' /* < new param */)
```

#### Backend: validate issued chain

```typescript
const options = { issuer: 'https://market.decentraland.org' }  /* < we will validate a chain generated with this isser */ 


/** OK: Only chains with the same issuer will be accepted as valid */
Authenticator.validateSignature(message, marketChain, provider, options)
// ok = true,


/** ERROR: It will fail if the chain was signed with another issuer */
Authenticator.validateSignature(message, eventsChain /* chain with otherissuer */, provider, options)
// ok = false,
// error = 'Invalid issuer. Expected: "https://market.decentraland.org" got "https://events.decentraland.org'"'


/** ERROR: It will fail if the chain was signed without issuer */
Authenticator.validateSignature(message, currentChain /* unissued chain */, provider, options)
// ok = false
// error = 'Invalid issuer. Expected: "https://market.decentraland.org" got null'


/** OK: It preserves the current behaviour */
Authenticator.validateSignature(message, currentChain /* unissued chain */, provider)
// ok = true


/* OK: validate any issuer */
Authenticator.validateSignature(message, currentChain /* unissued chain */, { issuer: '*' })
Authenticator.validateSignature(message, marketChain /* market chain */, { issuer: '*' })
Authenticator.validateSignature(message, eventsChain /* events chain */, { issuer: '*' })
// ok = true

```
