### PR TITLE
feat: bump schemas to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/schemas": "^5.4.2",
+        "@dcl/schemas": "^5.12.0",
         "eth-connect": "^6.0.3",
         "ethereum-cryptography": "^1.0.3"
       },
@@ -625,9 +625,9 @@
       }
     },
     "node_modules/@dcl/schemas": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.10.0.tgz",
-      "integrity": "sha512-pyj3g7XtPl7Q+YPsHRKmMWRpUr6RBTsLh1wpbOFSG8Kx72edp6dgOrCQq3c7tE4C3CEsu59Yq0ef6O0G4fPQEQ==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.12.0.tgz",
+      "integrity": "sha512-+vgimO2NkdQy/L1K7xM/2lMf8/B8+JS3rjreE9HYpqZOJQEvHIOi35yJev1KB2GIkYH81tJvjv3oJT7bX1YqjA==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -8210,9 +8210,9 @@
       }
     },
     "@dcl/schemas": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.10.0.tgz",
-      "integrity": "sha512-pyj3g7XtPl7Q+YPsHRKmMWRpUr6RBTsLh1wpbOFSG8Kx72edp6dgOrCQq3c7tE4C3CEsu59Yq0ef6O0G4fPQEQ==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.12.0.tgz",
+      "integrity": "sha512-+vgimO2NkdQy/L1K7xM/2lMf8/B8+JS3rjreE9HYpqZOJQEvHIOi35yJev1KB2GIkYH81tJvjv3oJT7bX1YqjA==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/decentraland/decentraland-crypto#readme",
   "dependencies": {
-    "@dcl/schemas": "^5.4.2",
+    "@dcl/schemas": "^5.12.0",
     "eth-connect": "^6.0.3",
     "ethereum-cryptography": "^1.0.3"
   },


### PR DESCRIPTION
The `ChainId` enum has been updated in the schemas library so now it's mismatching in some of our apps.